### PR TITLE
fix: Add release workflow to path triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - "build.gradle.kts"
       - "settings.gradle.kts"
       - "gradle/**"
+      - ".github/workflows/release.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

Fixes the issue where the release workflow was not triggering when only the workflow file itself was modified.

## Problem

When PR #9 was merged, only CodeQL ran but the release workflow did not trigger. This happened because:

- The release workflow has a `paths` filter that only triggers on changes to:
  - `app/**`
  - `build.gradle.kts`
  - `settings.gradle.kts`
  - `gradle/**`
- The `.github/workflows/release.yml` file was not included in this list
- CodeQL has no path filter, so it ran successfully

## Solution

Added `.github/workflows/release.yml` to the paths filter so the release workflow will now trigger when the workflow file itself is modified.

## Changes

- Added `.github/workflows/release.yml` to the `paths` trigger in the release workflow